### PR TITLE
Libdatachannel split build according to OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
       - '**.md'
     branches:
       - master
+      - libdatachannel
 
 jobs:
   ffmpeg-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -463,6 +463,7 @@ jobs:
           - target: x86
             config: 'Release'
             type: 'static'
+    needs: [ffmpeg-build]
     env:
       CACHE_REVISION: '3'
     defaults:

--- a/deps.ffmpeg/60-mbedtls.zsh
+++ b/deps.ffmpeg/60-mbedtls.zsh
@@ -3,21 +3,27 @@ autoload -Uz log_debug log_error log_info log_status log_output
 ## Dependency Information
 local name='mbedtls'
 local -A versions=(
-  macos 3.2.1
-  linux 3.2.1
-  windows 3.2.1
+  macos 3.4.0
+  linux 3.4.0
+  windows 3.4.0
 )
 local url='https://github.com/Mbed-TLS/mbedtls.git'
 local -A hashes=(
-  macos 869298bffeea13b205343361b7a7daf2b210e33d
-  linux 869298bffeea13b205343361b7a7daf2b210e33d
-  windows 869298bffeea13b205343361b7a7daf2b210e33d
+  macos 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+  linux 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+  windows 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
 )
 local -a patches=(
   "macos ${0:a:h}/patches/mbedtls/0001-enable-posix-threading-support.patch \
     ea52cf47ca01211cbadf03c0493986e8d4e0d1e9ab4aaa42365b2dea7b591188"
+  "macos ${0:a:h}/patches/mbedtls/0002-enable-dtls-srtp-support.patch \
+    bca47a5a51ef32f562b470fa330876862c6bc29c89b4c16ae2ea1edc46f703cb"
   "linux ${0:a:h}/patches/mbedtls/0001-enable-posix-threading-support.patch \
     ea52cf47ca01211cbadf03c0493986e8d4e0d1e9ab4aaa42365b2dea7b591188"
+  "linux ${0:a:h}/patches/mbedtls/0002-enable-dtls-srtp-support.patch \
+    bca47a5a51ef32f562b470fa330876862c6bc29c89b4c16ae2ea1edc46f703cb"
+  "windows ${0:a:h}/patches/mbedtls/0002-enable-dtls-srtp-support.patch \
+    bca47a5a51ef32f562b470fa330876862c6bc29c89b4c16ae2ea1edc46f703cb"
 )
 
 ## Dependency Overrides

--- a/deps.ffmpeg/70-libdatachannel.zsh
+++ b/deps.ffmpeg/70-libdatachannel.zsh
@@ -1,0 +1,85 @@
+autoload -Uz log_debug log_error log_info log_status log_output
+
+## Dependency Information
+local name='libdatachannel'
+local version='0.19.0'
+local url='https://github.com/paullouisageneau/libdatachannel.git'
+local hash='004c6b74ffa1d2718499b84d5bd7674d94b83dbc'
+
+## Dependency Overrides
+local targets=('macos-*' 'linux-*')
+local -i shared_libs=1
+local dir="${name}-${version}"
+
+## Build Steps
+setup() {
+  log_info "Setup (%F{3}${target}%f)"
+  setup_dep ${url} ${hash}
+}
+
+clean() {
+  cd "${dir}"
+
+  if [[ ${clean_build} -gt 0 && -d "build_${arch}" ]] {
+    log_info "Clean build directory (%F{3}${target}%f)"
+
+    rm -rf "build_${arch}"
+  }
+}
+
+config() {
+  autoload -Uz mkcd progress
+
+  local _onoff=(OFF ON)
+
+  args=(
+    ${cmake_flags}
+    -DENABLE_SHARED="${_onoff[(( shared_libs + 1 ))]}"
+    -DUSE_MBEDTLS=1
+    -DNO_WEBSOCKET=1
+    -DNO_TESTS=1
+    -DNO_EXAMPLES=1
+  )
+
+  log_info "Config (%F{3}${target}%f)"
+  cd "${dir}"
+  log_debug "CMake configuration options: ${args}'"
+  progress cmake -S . -B "build_${arch}" -G Ninja ${args}
+}
+
+build() {
+  autoload -Uz mkcd progress
+
+  log_info "Build (%F{3}${target}%f)"
+
+  cd "${dir}"
+
+  args=(
+    --build "build_${arch}"
+    --config "${config}"
+  )
+
+  if (( _loglevel > 1 )) args+=(--verbose)
+
+  cmake ${args}
+}
+
+install() {
+  autoload -Uz progress
+
+  log_info "Install (%F{3}${target}%f)"
+
+  args=(
+    --install "build_${arch}"
+    --config "${config}"
+  )
+
+  if [[ "${config}" =~ "Release|MinSizeRel" ]] args+=(--strip)
+  if (( _loglevel > 1 )) args+=(--verbose)
+
+  cd "${dir}"
+  progress cmake ${args}
+}
+
+fixup() {
+}

--- a/deps.ffmpeg/patches/mbedtls/0002-enable-dtls-srtp-support.patch
+++ b/deps.ffmpeg/patches/mbedtls/0002-enable-dtls-srtp-support.patch
@@ -1,0 +1,11 @@
+--- ./include/mbedtls/mbedtls_config.h
++++ ./include/mbedtls/mbedtls_config.h
+@@ -1788,7 +1788,7 @@
+  *
+  * Uncomment this to enable support for use_srtp extension.
+  */
+-//#define MBEDTLS_SSL_DTLS_SRTP
++#define MBEDTLS_SSL_DTLS_SRTP
+ 
+ /**
+  * \def MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE

--- a/deps.windows/70-libdatachannel.ps1
+++ b/deps.windows/70-libdatachannel.ps1
@@ -1,0 +1,76 @@
+param(
+    [string] $Name = 'libdatachannel',
+    [string] $Version = '0.19.0',
+    [string] $Uri = 'https://github.com/paullouisageneau/libdatachannel.git',
+    [string] $Hash = '004c6b74ffa1d2718499b84d5bd7674d94b83dbc'
+)
+
+function Setup {
+    Invoke-GitCheckout -Uri $Uri -Commit $Hash
+}
+
+function Clean {
+    Set-Location $Path
+
+    if ( Test-Path "build_${Target}" ) {
+        Log-Information "Clean build directory (${Target})"
+        Remove-Item -Path "build_${Target}" -Recurse -Force
+    }
+}
+
+function Patch {
+    Log-Information "Patch (${Target})"
+    Set-Location $Path
+
+    $Patches | ForEach-Object {
+        $Params = $_
+        Safe-Patch @Params
+    }
+}
+
+function Configure {
+    Log-Information "Configure (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        $CmakeOptions
+        '-DUSE_MBEDTLS=1'
+        '-DNO_WEBSOCKET=1'
+        '-DNO_TESTS=1'
+        '-DNO_EXAMPLES=1'
+    )
+
+    Invoke-External cmake -S . -B "build_${Target}" @Options
+}
+
+function Build {
+    Log-Information "Build (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--build', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $VerbosePreference -eq 'Continue' ) {
+        $Options += '--verbose'
+    }
+
+    Invoke-External cmake @Options
+}
+
+function Install {
+    Log-Information "Install (${Target})"
+    Set-Location $Path
+
+    $Options = @(
+        '--install', "build_${Target}"
+        '--config', $Configuration
+    )
+
+    if ( $Configuration -match "(Release|MinSizeRel)" ) {
+        $Options += '--strip'
+    }
+
+    Invoke-External cmake @Options
+}


### PR DESCRIPTION
Edit: don't merge. I've forgotten a step where the mbedtls libs are copied to the windows deps folder. So CI fails for now.


This splits the building of datachannel for windows to use the powershell script on msvc.
I've split also the commits to have mbedtls separate for easier revert if needs be.
You'll have to drop the last commit and rebase.